### PR TITLE
fix: add [build-system] to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["poetry"]
+build-backend = "poetry.masonry.api"
+
 [tool.poetry]
 name = "sansio-lsp-client"
 version = "0.6.1"


### PR DESCRIPTION
this should fix the issue of pip not being able to install this package
because [build-system] is the way to tell pip how to install a package that
doesn't have a setup.py (see PEP 517)

closes #6