### PR TITLE
fix and simplify how io_handler works

### DIFF
--- a/sansio_lsp_client/__init__.py
+++ b/sansio_lsp_client/__init__.py
@@ -3,7 +3,6 @@
 from .client import *
 from .events import *
 from .structs import *
-from .errors import *
 from .utils import *
 
 __version__ = "0.6.1"

--- a/sansio_lsp_client/client.py
+++ b/sansio_lsp_client/client.py
@@ -104,13 +104,8 @@ class Client:
     def recv(self, data: bytes) -> t.List[Event]:
         self._recv_buf += data
 
-        # We must exhaust the generator so IncompleteResponseError
-        # is raised before we actually process anything.
+        # _parse_messages deletes consumed data from self._recv_buf
         messages = list(_parse_messages(self._recv_buf))
-
-        # If we get here, that means the previous line didn't error out so we
-        # can just clear whatever we were holding.
-        self._recv_buf.clear()
 
         events = []
         for message in messages:

--- a/sansio_lsp_client/errors.py
+++ b/sansio_lsp_client/errors.py
@@ -1,4 +1,0 @@
-class IncompleteResponseError(Exception):
-    def __init__(self, msg: str, *, missing_bytes: int = None) -> None:
-        super().__init__(msg)
-        self.missing_bytes = missing_bytes


### PR DESCRIPTION
Previously `io_handler` would queue Requests and Responses until the bytes fed to it would happen to get consumed completely with no bytes left over. Sometimes it also parsed the same Requests or Response multiple times.

This pull request is not backwards compatible because it deletes `IncompleteResponseError`. Instead of this...

```python3
try:
    lsp_events = client_object.recv(bytes_from_langserver)
except IncompleteResponseError:
    pass
else:
    for event in lsp_events:
        do_something_with(event)
```

...you now need to do this:

```python3
lsp_events = client_object.recv(bytes_from_langserver)
for event in lsp_events:
    do_something_with(event)
```
