### PR TITLE
make mypy recognize this package as having type hints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/PurpleMyst/sansio-lsp-client"
 keywords = ["sansio", "languageserver"]
+include = ["sansio_lsp_client/py.typed"]
 
 [tool.poetry.dependencies]
 python = ">=3.6"


### PR DESCRIPTION
Mypy searches for this file, and if it's not found, it says that sansio_lsp_client has no type hints. I learned this by reading mypy's source code and I don't know if this is documented somewhere.