### PR TITLE
More tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     - shell: bash
       run: |
         cd test_langservers
-        for version in 10.0.0 11.0.0; do
+        for VERSION in 10.0.0 11.0.0; do
           wget "https://github.com/clangd/clangd/releases/download/$VERSION/clangd-linux-$VERSION.zip"
           python3 -m zipfile -e "clangd-linux-$VERSION.zip" .
           chmod +x clangd_$VERSION/bin/clangd

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,11 @@ jobs:
       with:
         node-version: '12'
     - run: |
-        mkdir jsts-langserver && cd jsts-langserver && npm install javascript-typescript-langserver
+        mkdir test_langservers
+    - run: |
+        cd test_langservers && npm install javascript-typescript-langserver
+    - run: |
+        cd test_langservers && wget 'https://github.com/clangd/clangd/releases/download/11.0.0/clangd-linux-11.0.0.zip' && python3 -m zipfile -e clangd-linux-*.zip . && chmod +x clangd_*/bin/clangd
     - run: |
         pip install poetry && poetry install
     - run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,11 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '12'
+    - run: |
+        mkdir jsts-langserver && cd jsts-langserver && npm install javascript-typescript-langserver
     - run: |
         pip install poetry && poetry install
     - run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,8 @@ jobs:
         mkdir test_langservers
     - run: |
         cd test_langservers && npm install javascript-typescript-langserver
-    - run: |
+    - shell: bash
+      run: |
         cd test_langservers
         for version in 10.0.0 11.0.0; do
           wget "https://github.com/clangd/clangd/releases/download/$VERSION/clangd-linux-$VERSION.zip"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,12 @@ jobs:
     - run: |
         cd test_langservers && npm install javascript-typescript-langserver
     - run: |
-        cd test_langservers && wget 'https://github.com/clangd/clangd/releases/download/11.0.0/clangd-linux-11.0.0.zip' && python3 -m zipfile -e clangd-linux-*.zip . && chmod +x clangd_*/bin/clangd
+        cd test_langservers
+        for version in 10.0.0 11.0.0; do
+          wget "https://github.com/clangd/clangd/releases/download/$VERSION/clangd-linux-$VERSION.zip"
+          python3 -m zipfile -e "clangd-linux-$VERSION.zip" .
+          chmod +x clangd_$VERSION/bin/clangd
+        done
     - run: |
         pip install poetry && poetry install
     - run: |

--- a/.gitignore
+++ b/.gitignore
@@ -134,4 +134,4 @@ tags
 
 
 # test stuff
-jsts-langserver/
+test_langservers/

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,7 @@ tags
 
 
 # End of https://www.gitignore.io/api/vim,python
+
+
+# test stuff
+jsts-langserver/

--- a/tests.py
+++ b/tests.py
@@ -159,7 +159,5 @@ do_""",
         [next(test_langservers.glob("clangd_*")) / "bin" / "clangd"],
     )
     # TODO
-
-
-#    assert diagnostics.diagnostics == [...]
-#    assert [item.label for item in completions.completion_list.items] == [...]
+    # assert diagnostics.diagnostics == [...]
+    # assert [item.label for item in completions.completion_list.items] == [...]

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,6 @@
 import contextlib
 import pathlib
+import shutil
 import subprocess
 import sys
 
@@ -9,9 +10,9 @@ import sansio_lsp_client as lsp
 
 
 @contextlib.contextmanager
-def run_stdio_langserver(project_root, command, **popen_kwargs):
+def run_langserver(project_root, command):
     with subprocess.Popen(
-        command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, **popen_kwargs
+        command, stdin=subprocess.PIPE, stdout=subprocess.PIPE
     ) as process:
         lsp_client = lsp.Client(
             trace="verbose", root_uri=project_root.as_uri()
@@ -29,20 +30,52 @@ def run_stdio_langserver(project_root, command, **popen_kwargs):
         yield (lsp_client, make_event_iterator())
 
 
-def test_pyls(tmp_path):
-    foo_uri = (tmp_path / "foo.py").as_uri()
+def do_stuff_with_a_langserver(
+    tmp_path, filename, file_content, command, cwd=None
+):
+    path = tmp_path / filename
+    path.write_text(file_content)
 
-    with run_stdio_langserver(tmp_path, [sys.executable, "-m", "pyls"]) as (
-        lsp_client,
-        event_iter,
-    ):
+    with run_langserver(tmp_path, command) as (lsp_client, event_iter):
         inited = next(event_iter)
         assert isinstance(inited, lsp.Initialized)
         lsp_client.did_open(
             lsp.TextDocumentItem(
-                uri=foo_uri,
+                uri=path.as_uri(),
                 languageId="python",
-                text="""\
+                text=file_content,
+                version=0,
+            )
+        )
+
+        diagnostics = next(event_iter)
+        assert isinstance(diagnostics, lsp.PublishDiagnostics)
+        assert diagnostics.uri == path.as_uri()
+
+        event_id = lsp_client.completions(
+            text_document_position=lsp.TextDocumentPosition(
+                textDocument=lsp.TextDocumentIdentifier(uri=path.as_uri()),
+                position=lsp.Position(
+                    # first line = 0, first column = 0
+                    line=file_content.count("\n"),
+                    character=len(file_content.split("\n")[-1]),
+                ),
+            ),
+            context=lsp.CompletionContext(
+                triggerKind=lsp.CompletionTriggerKind.INVOKED
+            ),
+        )
+        completions = next(event_iter)
+        assert completions.message_id == event_id
+
+        return (diagnostics, completions)
+
+
+def test_pyls(tmp_path):
+    diagnostics, completions = do_stuff_with_a_langserver(
+        tmp_path,
+        "foo.py",
+        """\
 import sys
 def do_foo():
     pass
@@ -50,88 +83,50 @@ def do_bar():
     pass
 
 do_""",
-                version=0,
-            )
-        )
+        [sys.executable, "-m", "pyls"],
+    )
 
-        diagnostics = next(event_iter)
-        assert isinstance(diagnostics, lsp.PublishDiagnostics)
-        assert diagnostics.uri == foo_uri
-        assert [diag.message for diag in diagnostics.diagnostics] == [
-            "'sys' imported but unused",
-            "undefined name 'do_'",
-            "E302 expected 2 blank lines, found 0",
-            "E302 expected 2 blank lines, found 0",
-            "W292 no newline at end of file",
-            "E305 expected 2 blank lines after class or function definition, found 1",
-        ]
+    assert [diag.message for diag in diagnostics.diagnostics] == [
+        "'sys' imported but unused",
+        "undefined name 'do_'",
+        "E302 expected 2 blank lines, found 0",
+        "E302 expected 2 blank lines, found 0",
+        "W292 no newline at end of file",
+        "E305 expected 2 blank lines after class or function definition, found 1",
+    ]
 
-        event_id = lsp_client.completions(
-            text_document_position=lsp.TextDocumentPosition(
-                textDocument=lsp.TextDocumentIdentifier(uri=foo_uri),
-                position=lsp.Position(line=6, character=3),
-            ),
-            context=lsp.CompletionContext(
-                triggerKind=lsp.CompletionTriggerKind.INVOKED
-            ),
-        )
-        completion = next(event_iter)
-        assert completion.message_id == event_id
-        assert [item.label for item in completion.completion_list.items] == [
-            "do_bar()",
-            "do_foo()",
-        ]
+    assert [item.label for item in completions.completion_list.items] == [
+        "do_bar()",
+        "do_foo()",
+    ]
 
 
-jstsls_path = pathlib.Path(__name__).absolute().parent / 'jsts-langserver'
+jstsls_path = pathlib.Path(__name__).absolute().parent / "jsts-langserver"
 
 
 @pytest.mark.skipif(
     not jstsls_path.exists(),
-    reason=f"javascript-typescript-langserver not installed into {jstsls_path}"
+    reason=f"javascript-typescript-langserver not installed into {jstsls_path}",
+)
+@pytest.mark.skipif(
+    shutil.which("node") is None, reason="node not found in $PATH"
 )
 def test_javascript_typescript_langserver(tmp_path):
-    foo_path = tmp_path / "foo.js"
-    foo_path.write_text("""\
+    diagnostics, completions = do_stuff_with_a_langserver(
+        tmp_path,
+        "foo.js",
+        """\
 const blah = require("asdf");
 function doSomethingWithFoo() {
 }
 function doSomethingWithBar() {
 }
 
-doS""")
-
-    with run_stdio_langserver(
-        tmp_path, [jstsls_path / 'node_modules' / '.bin' / 'javascript-typescript-stdio'], cwd=tmp_path
-    ) as (lsp_client, event_iter):
-        inited = next(event_iter)
-        assert isinstance(inited, lsp.Initialized)
-        lsp_client.did_open(
-            lsp.TextDocumentItem(
-                uri=foo_path.as_uri(),
-                languageId="javascript",
-                text=foo_path.read_text(),
-                version=0,
-            )
-        )
-
-        diagnostics = next(event_iter)
-        assert isinstance(diagnostics, lsp.PublishDiagnostics)
-        assert diagnostics.uri == foo_path.as_uri()
-        assert [diag.message for diag in diagnostics.diagnostics] == []
-
-        event_id = lsp_client.completions(
-            text_document_position=lsp.TextDocumentPosition(
-                textDocument=lsp.TextDocumentIdentifier(uri=foo_path.as_uri()),
-                position=lsp.Position(line=6, character=3),
-            ),
-            context=lsp.CompletionContext(
-                triggerKind=lsp.CompletionTriggerKind.INVOKED
-            ),
-        )
-        completion = next(event_iter)
-        assert completion.message_id == event_id
-        assert [item.label for item in completion.completion_list.items[:2]] == [
-            "doSomethingWithFoo",
-            "doSomethingWithBar",
-        ]
+doS""",
+        [jstsls_path / "node_modules/.bin/javascript-typescript-stdio"],
+    )
+    assert not diagnostics.diagnostics
+    assert [item.label for item in completions.completion_list.items[:2]] == [
+        "doSomethingWithFoo",
+        "doSomethingWithBar",
+    ]

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,5 @@
 import contextlib
-import shutil
+import pathlib
 import subprocess
 import sys
 
@@ -83,9 +83,14 @@ do_""",
         ]
 
 
-@pytest.mark.skipif(shutil.which("npm") is None, reason="npm not installed")
+jstsls_path = pathlib.Path(__name__).absolute().parent / 'jsts-langserver'
+
+
+@pytest.mark.skipif(
+    not jstsls_path.exists(),
+    reason=f"javascript-typescript-langserver not installed into {jstsls_path}"
+)
 def test_javascript_typescript_langserver(tmp_path):
-    subprocess.call(["npm", "install", "javascript-typescript-langserver"], cwd=tmp_path)
     foo_path = tmp_path / "foo.js"
     foo_path.write_text("""\
 const blah = require("asdf");
@@ -97,7 +102,7 @@ function doSomethingWithBar() {
 doS""")
 
     with run_stdio_langserver(
-        tmp_path, 'node_modules/.bin/javascript-typescript-stdio', cwd=tmp_path
+        tmp_path, [jstsls_path / 'node_modules' / '.bin' / 'javascript-typescript-stdio'], cwd=tmp_path
     ) as (lsp_client, event_iter):
         inited = next(event_iter)
         assert isinstance(inited, lsp.Initialized)


### PR DESCRIPTION
- javascript-typescript-langserver test (works)
- clangd 10 test (works)
- clangd 11 test (fails, remove `@pytest.mark.xfail` to see failure)