### PR TITLE
run mypy on different python versions

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -5,11 +5,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Mypy
+    strategy:
+      matrix:
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1
       with:
-        python-version: 3.9
+        python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
       run: |
         pip install poetry && poetry install


### PR DESCRIPTION
This catches mypy errors that don't happen on Python 3.9, such as using Python 3.9 only features.