### PR TITLE
disallow List[CompletionItem] in Completion.completion_list

### DIFF
--- a/sansio_lsp_client/events.py
+++ b/sansio_lsp_client/events.py
@@ -68,7 +68,7 @@ class LogMessage(ServerNotification):
 # XXX: should these two be just Events or?
 class Completion(Event):
     message_id: Id
-    completion_list: t.Union[CompletionList, t.List[CompletionItem], None]
+    completion_list: t.Optional[CompletionList]
 
 
 # XXX: not sure how to name this event.


### PR DESCRIPTION
Allows me to get rid of an `isinstance` check which in fact always produces the same result. Does not break backwards compatibility.