### PR TITLE
remove __import__ hack

### DIFF
--- a/sansio_lsp_client/client.py
+++ b/sansio_lsp_client/client.py
@@ -1,4 +1,5 @@
 import enum
+import pprint
 import typing as t
 
 from pydantic import parse_obj_as, ValidationError
@@ -113,8 +114,7 @@ class Client:
 
         # FIXME: The errors have meanings.
         if response.error is not None:
-            __import__("pprint").pprint(response.error)
-            raise RuntimeError("Response error!")
+            raise RuntimeError("Response error!\n\n" + pprint.pformat(response.error))
 
         event: Event
 


### PR DESCRIPTION
With this change, response errors will be visible in Porcupine's log files. Porcupine doesn't redirect stdout to the log, but exceptions get logged.