### PR TITLE
github actions: prevent running everything twice

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,6 +1,12 @@
 # mostly copied from mypy.yml
 name: Black
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,6 +1,12 @@
 # https://medium.com/@doedotdev/mypy-for-github-action-7da1ebee99e7
 name: Mypy
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,11 @@
 name: Tests
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
 jobs:
   pytest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
GitHub actions is a bit weird. If you specify `on:  [push, pull_request]`, then it will run twice when you push to a pull request branch on the not-forked repo. There doesn't seem to be a way to say "push to a branch without pull request", but in practice, "push to master" is close enough as non-master branches should usually be made into pull requests anyway.

I have used a similar config in Porcupine for a while now. It runs the CI exactly once in all cases I care about:
- I create a pull request from `Akuli/porcupine` to `Akuli/porcupine`
- Someone else creates a pull request from their fork, e.g. `ThePhilgrim/porcupine` to `Akuli/porcupine`
- I push to master.