### PR TITLE
add pyflakes linter

### DIFF
--- a/.github/workflows/pyflakes.yml
+++ b/.github/workflows/pyflakes.yml
@@ -1,0 +1,24 @@
+name: Lint with pyflakes
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  pyflakes:
+    runs-on: ubuntu-latest
+    name: Pyflakes
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install Dependencies
+      run: |
+        pip install poetry && poetry install
+    - name: Run pyflakes
+      run: |
+        # Skip __init__.py because it contains star imports
+        poetry run python3 -m pyflakes $(git ls-files '*.py' | grep -v __init__.py)

--- a/poetry.lock
+++ b/poetry.lock
@@ -520,7 +520,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6"
-content-hash = "b40e62cc462904d1a36e8d20603c8b8c18479d7176d293ae0acf5b75b46680dd"
+content-hash = "e9c712200e5bb57752ce024bfaa985af386ef865fa8ac608efb78474d85b5cab"
 
 [metadata.files]
 appdirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ python-language-server = { extras = ["all"], version = "^0.36.2" }
 pytest = "5.4.3"
 pytest-cov = "^2.10.1"
 lxml = "^4.6.2"
+pyflakes = "^2.2.0"
 
 [tool.black]
 line-length = 88

--- a/sansio_lsp_client/events.py
+++ b/sansio_lsp_client/events.py
@@ -9,7 +9,6 @@ from .structs import (
     Diagnostic,
     MessageType,
     MessageActionItem,
-    CompletionItem,
     CompletionList,
     TextEdit,
 )


### PR DESCRIPTION
Flake8 combines two linters, pyflakes and pycodestyle. We don't want pycodestyle because it uses black, but pyflakes is still useful for e.g. unused imports.