### PR TITLE
feat: capabilities parameter for Client

### DIFF
--- a/sansio_lsp_client/client.py
+++ b/sansio_lsp_client/client.py
@@ -137,7 +137,11 @@ class Client:
         root_uri: t.Optional[str] = None,
         workspace_folders: t.Optional[t.List[WorkspaceFolder]] = None,
         trace: str = "off",
+        capabilities: dict = None,
     ) -> None:
+        if not capabilities:
+            capabilities = CAPABILITIES
+
         self._state = ClientState.NOT_INITIALIZED
 
         # Used to save data as it comes in (from `recieve_bytes`) until we have
@@ -168,7 +172,7 @@ class Client:
                     else [f.dict() for f in workspace_folders]
                 ),
                 "trace": trace,
-                "capabilities": CAPABILITIES,
+                "capabilities": capabilities,
             },
         )
         self._state = ClientState.WAITING_FOR_INITIALIZED


### PR DESCRIPTION
It's useful to be able to change the capabilities for a client. I'm using `clangd` and there are capabilities I'd like to enable, such as [inline fixes for diagnostics](https://clangd.llvm.org/extensions#inline-fixes-for-diagnostics).